### PR TITLE
Ensure Changesets pushes release tags

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -37,7 +37,7 @@ jobs:
         uses: changesets/action@v1
         with:
           createGithubReleases: false
-          publish: pnpm changeset tag
+          publish: pnpm changeset tag && git push --follow-tags
           commit: Apply changesets
           commitMode: github-api
         env:


### PR DESCRIPTION
## Context
The Changesets workflow created annotated v* tags but never pushed them back to GitHub, so CD never fired.

## Key changes
- Update `.github/workflows/changesets.yml` so the publish step runs `pnpm changeset tag && git push --follow-tags`, guaranteeing new tags are pushed upstream alongside the release commit.