### PR TITLE
Ensure release workflow pushes tags correctly

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -35,10 +35,14 @@ jobs:
 
       - name: Publish with Changesets
         uses: changesets/action@v1
+        id: changesets
         with:
           createGithubReleases: false
-          publish: pnpm changeset tag && git push --follow-tags
+          publish: pnpm changeset tag
           commit: Apply changesets
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_PAT }}
+
+      - name: Push tags
+        run: git push --follow-tags


### PR DESCRIPTION
## Context
Currently, the Changesets workflow fails because the publish command passes multiple arguments; GitHub Actions rejects it before tags are pushed.

## Key changes
- Update `.github/workflows/changesets.yml` so `changesets/action@v1` runs only `pnpm changeset tag`.
- Add a follow-up step that runs `git push --follow-tags` to publish the new tag to GitHub after the action succeeds.